### PR TITLE
Fix bug where zooming, clicking the reset button, and zooming again preserves the original zoom state

### DIFF
--- a/src/components/Zooming/Container.tsx
+++ b/src/components/Zooming/Container.tsx
@@ -13,17 +13,21 @@ export default function ZoomableContainer({ children }: Props) {
 
   // `movement` stores the offset since you started pinching.
   // Eg. if you zoom to 5, stop, and start again, movement will reset to 1.
-  // We know that you've stopped pinching when `delta` is 0, so that's when
-  // we set mostRecentZoom. If you've reset the zoom, we set mostRecentZoom to 1.
   usePinch(
     (props) => {
       const movement = props.movement[0]
+
+      // Did the user just reset the zoom?
+      // If so, set mostRecentZoom to 1.
+      // If not, multiply the most recent zoom by the movement.
       if (zoom === 1) {
-        setZoom(movement)
         setMostRecentZoom(1)
+        setZoom(movement)
       } else {
         setZoom(mostRecentZoom * movement)
       }
+
+      // User has stopped pinching, so set most recent zoom.
       if (props.delta[0] === 0) {
         setMostRecentZoom(mostRecentZoom * movement)
       }

--- a/src/components/Zooming/Container.tsx
+++ b/src/components/Zooming/Container.tsx
@@ -9,14 +9,14 @@ type Props = {
 }
 export default function ZoomableContainer({ children }: Props) {
   const [zoom, setZoom] = useAtom(zoomAtom)
-  console.log({ zoom })
 
-  // Problem: offset can get out of sync when the user clicks reset,
-  // which sets the zoom to 1 but leaves offset unchanged.
   usePinch(
-    ({ offset: [d] }) => {
-      console.log({ ofset: d })
-      setZoom(d)
+    // `difference` stores the delta between the previous and current offset.
+    // Setting the zoom using `difference` rather than `offset` means that when
+    // the user clicks ResetZoom, offset will be out of sync with zoom but
+    // difference will still be correct.
+    ({ delta: [difference] }) => {
+      setZoom((zoom) => zoom + difference)
     },
     {
       target: typeof document !== 'undefined' ? document : undefined,

--- a/src/components/Zooming/Container.tsx
+++ b/src/components/Zooming/Container.tsx
@@ -9,8 +9,13 @@ type Props = {
 }
 export default function ZoomableContainer({ children }: Props) {
   const [zoom, setZoom] = useAtom(zoomAtom)
+  console.log({ zoom })
+
+  // Problem: offset can get out of sync when the user clicks reset,
+  // which sets the zoom to 1 but leaves offset unchanged.
   usePinch(
     ({ offset: [d] }) => {
+      console.log({ ofset: d })
       setZoom(d)
     },
     {

--- a/src/components/Zooming/Container.tsx
+++ b/src/components/Zooming/Container.tsx
@@ -9,7 +9,6 @@ type Props = {
 }
 export default function ZoomableContainer({ children }: Props) {
   const [zoom, setZoom] = useAtom(zoomAtom)
-
   usePinch(
     // `difference` stores the delta between the previous and current offset.
     // Setting the zoom using `difference` rather than `offset` means that when

--- a/src/components/Zooming/ResetZoom.tsx
+++ b/src/components/Zooming/ResetZoom.tsx
@@ -12,6 +12,7 @@ export function ResetZoomBtn() {
     <button
       title="Reset Zoom"
       className="btn btn-sm"
+      // Setting the zoom here doesn't affect the offset
       onClick={() => setZoom(1)}
     >
       <MdSearchOff />

--- a/src/components/Zooming/ResetZoom.tsx
+++ b/src/components/Zooming/ResetZoom.tsx
@@ -12,7 +12,6 @@ export function ResetZoomBtn() {
     <button
       title="Reset Zoom"
       className="btn btn-sm"
-      // Setting the zoom here doesn't affect the offset
       onClick={() => setZoom(1)}
     >
       <MdSearchOff />


### PR DESCRIPTION
This change uses the `usePinch` `movement` field to set the zoom value so that it's not affected by clicking `ResetZoom`.

https://www.loom.com/share/a97b856d4c744464804403cdca38367d?sid=c78ee9db-ec01-4225-951e-4b42a4e67459